### PR TITLE
fixed invalid yaml

### DIFF
--- a/config/syringe.yml
+++ b/config/syringe.yml
@@ -7,7 +7,7 @@ services:
         arguments:
             -
                 version: "2012-11-05"
-                region: %sqsRegion%
+                region: "%sqsRegion%"
 
     messageFactory:
         class: Silktide\QueueBall\Sqs\MessageFactory
@@ -15,10 +15,10 @@ services:
     sqsQueue:
         class: Silktide\QueueBall\Sqs\Queue
         arguments:
-            - @sqsClient
-            - @messageFactory
+            - "@sqsClient"
+            - "@messageFactory"
 
     # set the sqs queue to be default
     silktide_queueball.defaultQueue:
-        aliasOf: @sqsQueue
+        aliasOf: "@sqsQueue"
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -79,7 +79,9 @@ class Queue extends AbstractQueue
      */
     public function createQueue($queueId, $options = [])
     {
-        $timeout = empty($options["messageLockTimeout"])? self::DEFAULT_MESSAGE_LOCK_TIMEOUT: (int) $options["messageLockTimeout"];
+        $timeout = (empty($options["messageLockTimeout"]) || !is_numeric($options["messageLockTimeout"]))
+            ? self::DEFAULT_MESSAGE_LOCK_TIMEOUT
+            : (int) $options["messageLockTimeout"];
         $attributes = [
             "VisibilityTimeout" => $timeout
         ];

--- a/test/QueueTest.php
+++ b/test/QueueTest.php
@@ -3,7 +3,6 @@
 namespace Silktide\QueueBall\Sqs\Test;
 
 use Silktide\QueueBall\Exception\QueueException;
-use Silktide\QueueBall\Queue\AbstractQueue;
 use Silktide\QueueBall\Sqs\Queue;
 use Aws\Sqs\SqsClient;
 use Silktide\QueueBall\Message\QueueMessageFactoryInterface;
@@ -15,17 +14,17 @@ use Silktide\QueueBall\Message\QueueMessage;
 class QueueTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var SqsClient
+     * @var \Mockery\Mock|SqsClient
      */
     protected $sqsClient;
 
     /**
-     * @var QueueMessageFactoryInterface
+     * @var \Mockery\Mock|QueueMessageFactoryInterface
      */
     protected $messageFactory;
 
     /**
-     * @var QueueMessage
+     * @var \Mockery\Mock|QueueMessage
      */
     protected $queueMessage;
 
@@ -39,7 +38,9 @@ class QueueTest extends \PHPUnit_Framework_TestCase {
     {
 
         $this->queueUrl = "http://queue.com";
-        $urlReturn = \Mockery::mock("Guzzle\\Service\\Resource\\Model")->shouldReceive("get")->with("QueueUrl")->andReturn($this->queueUrl)->getMock();
+        /** @var \Mockery\Mock $urlReturn */
+        $urlReturn = \Mockery::mock("Guzzle\\Service\\Resource\\Model");
+        $urlReturn->shouldReceive("get")->with("QueueUrl")->andReturn($this->queueUrl)->getMock();
 
         $this->sqsClient = \Mockery::mock("Aws\\Sqs\\SqsClient");
         $this->sqsClient->shouldReceive("getQueueUrl")->andReturn($urlReturn);
@@ -104,11 +105,11 @@ class QueueTest extends \PHPUnit_Framework_TestCase {
             ],
             [ // default timeout
                 null,
-                AbstractQueue::DEFAULT_MESSAGE_LOCK_TIMEOUT
+                Queue::DEFAULT_MESSAGE_LOCK_TIMEOUT
             ],
             [ // default when timeout is invalid
                 "NAN",
-                AbstractQueue::DEFAULT_MESSAGE_LOCK_TIMEOUT
+                Queue::DEFAULT_MESSAGE_LOCK_TIMEOUT
             ]
         ];
     }
@@ -161,7 +162,9 @@ class QueueTest extends \PHPUnit_Framework_TestCase {
     {
         $messageArray = [1, 2, 3];
 
-        $message = \Mockery::mock("Guzzle\\Common\\Collection")->shouldReceive("toArray")->andReturn($messageArray)->getMock();
+        /** @var \Mockery\Mock $message */
+        $message = \Mockery::mock("Guzzle\\Common\\Collection");
+        $message->shouldReceive("toArray")->andReturn($messageArray)->getMock();
         $this->sqsClient->shouldReceive("receiveMessage")->with(["QueueUrl" => $this->queueUrl, "WaitTimeSeconds" => 0])->andReturn($message);
         $this->messageFactory->shouldReceive("createMessage")->with($messageArray, $this->queueId)->andReturn(true);
 

--- a/test/QueueTest.php
+++ b/test/QueueTest.php
@@ -92,7 +92,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase {
 
         $this->sqsClient->shouldReceive("createQueue")->atLeast()->times(1)->with($expectedArg);
 
-        $queue->createQueue($this->queueId, $timeout);
+        $queue->createQueue($this->queueId, ["messageLockTimeout" => $timeout]);
         $this->assertEquals($this->queueId, $queue->getQueueId());
     }
 
@@ -165,7 +165,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase {
         /** @var \Mockery\Mock $message */
         $message = \Mockery::mock("Guzzle\\Common\\Collection");
         $message->shouldReceive("toArray")->andReturn($messageArray)->getMock();
-        $this->sqsClient->shouldReceive("receiveMessage")->with(["QueueUrl" => $this->queueUrl, "WaitTimeSeconds" => 0])->andReturn($message);
+        $this->sqsClient->shouldReceive("receiveMessage")->with(["QueueUrl" => $this->queueUrl, "WaitTimeSeconds" => 20])->andReturn($message);
         $this->messageFactory->shouldReceive("createMessage")->with($messageArray, $this->queueId)->andReturn(true);
 
         $queue = new Queue($this->sqsClient, $this->messageFactory, $this->queueId);


### PR DESCRIPTION
As per symfony/symfony#16234 (and in more detail http://www.yaml.org/spec/1.2/spec.html#id2774157) using @ at the start of unquoted strings isn't valid yaml.

As of version 2.8 it throws warnings in symfony/yaml and throws parse errors in 3.0.

I've moved the values to being quoted instead (and thus spec compliant)